### PR TITLE
Fix python symlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Python scripts to replicate personal development environment across any machine with proper packaging and editor profiles and settings. Linux machine environment only.
 
 # Requirements
-- Python 3 system binary installed to run the script
+- Python3 to run the script
 - Run `pip3 install -r requirements` to fetch all script dependencies
 
 # Automated Process

--- a/config/brew/test-brew.txt
+++ b/config/brew/test-brew.txt
@@ -1,3 +1,2 @@
 git
 vim
-python

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ LOGGER = logging.getLogger()
 
 def install_brew_packages():
     '''
-    Install brew packages and uses brew python over system by replacing symlink
+    Install brew packages 
     '''
     packages = brew_helper.get_uninstalled_brew_packages()
 

--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,6 @@ def install_brew_packages():
     for package in packages:
         brew_helper.install_that_brew(package)
 
-    brew_helper.use_brew_python()
-
     SETUP.print_process_step('Installation of brew packages are complete!')
 
 def install_cask_packages():

--- a/utils/brew_helper.py
+++ b/utils/brew_helper.py
@@ -102,22 +102,6 @@ def install_that_brew(package: str):
             LOGGER.debug(out.decode('utf-8'))
             LOGGER.info('{package} - successfully installed')
 
-def use_brew_python():
-    '''
-    Replaces system binary path with symlink to brew python
-    '''
-    command = 'brew link --overwrite python'
-    with Popen(command.split(), stdout=PIPE, stderr=PIPE) as process:
-        out, err = process.communicate()
-
-        if err:
-            LOGGER.error(err.decode('utf-8'))
-            LOGGER.error('Failed to overwrite current python symlink with brew python')
-            sys.exit()
-        else:
-            LOGGER.debug(out.decode('utf-8'))
-            LOGGER.info('Brew python has successfully been symlinked')
-
 def get_uninstalled_cask_packages() -> list:
     '''
     Scans config list of cask packages to install what's missing


### PR DESCRIPTION
Force script application to rely on system python and avoid use of brew python based on the assumption that the use case of this script is to run a single time on clean slate machines